### PR TITLE
PT-5806: Fix - Content > User can't rename folder

### DIFF
--- a/src/VirtoCommerce.AssetsModule.Web/Scripts/blades/asset-list.tpl.html
+++ b/src/VirtoCommerce.AssetsModule.Web/Scripts/blades/asset-list.tpl.html
@@ -42,7 +42,7 @@
                     <li class="menu-item" ng-click="copyUrl(contextMenuEntity)">
                         <i class="menu-ico fas fa-link"></i> Copy link
                     </li>
-                    <li class="menu-item" ng-click="rename(contextMenuEntity)" ng-if="contextMenuEntity.type !== 'folder'">
+                    <li class="menu-item" ng-click="rename(contextMenuEntity)">
                         <i class="menu-ico fa fa-font"></i> Rename
                     </li>
                     <li class="menu-item" ng-click='delete(contextMenuEntity)' va-permission="platform:asset:delete">


### PR DESCRIPTION
## An option has been added to rename folders in Content, Assets
![image](https://user-images.githubusercontent.com/86958548/145361225-17e3c6ad-f34b-4b1b-a6c1-646f012f7cd8.png)

## References
### QA-test:
### Jira-link:
 https://virtocommerce.atlassian.net/browse/PT-5806
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Assets_1.3.0-pr-6.zip
