### PR TITLE
Prevent double encoding of asset's url

### DIFF
--- a/src/VirtoCommerce.AssetsModule.Web/Controllers/AssetsController.cs
+++ b/src/VirtoCommerce.AssetsModule.Web/Controllers/AssetsController.cs
@@ -159,6 +159,7 @@ namespace VirtoCommerce.AssetsModule.Web.Controllers
                         {
                             var fileName = contentDisposition.FileName.Value;
                             var targetFilePath = UrlHelpers.Combine(folderUrl ?? "", Uri.EscapeDataString(fileName));
+                            var rawTargetFilePath = UrlHelpers.Combine(folderUrl ?? "", fileName);
 
                             using (var targetStream = await _blobProvider.OpenWriteAsync(targetFilePath))
                             {
@@ -168,7 +169,7 @@ namespace VirtoCommerce.AssetsModule.Web.Controllers
                             var blobInfo = AbstractTypeFactory<BlobInfo>.TryCreateInstance();
                             blobInfo.Name = fileName;
                             blobInfo.RelativeUrl = targetFilePath;
-                            blobInfo.Url = _urlResolver.GetAbsoluteUrl(targetFilePath);
+                            blobInfo.Url = _urlResolver.GetAbsoluteUrl(rawTargetFilePath);
                             blobInfo.ContentType = MimeTypeResolver.ResolveContentType(fileName);
                             result.Add(blobInfo);
                         }


### PR DESCRIPTION
## Description

There's a bug in `AssetsController` that causes the absolute url in `BlobInfo` to be encoded twice after an asset has been uploaded. Here's a sample response from `AssetsController.UploadAssetAsync()` that demonstrates this phenomenon:
```json
[
    {
        "size": 0,
        "contentType": "application/zip",
        "type": "blob",
        "name": "PROFIM Normo V - OBJ.zip",
        "url": "https://sample-domain.com/catalog/profim-normo/PROFIM%2520Normo%2520V%2520-%2520OBJ.zip",
        "relativeUrl": "catalog/profim-normo/PROFIM%20Normo%20V%20-%20OBJ.zip",
        "createdDate": "0001-01-01T00:00:00Z"
    }
]
```

Note how the file name in `url` property is excessively encoded:
* `PROFIM%2520Normo%2520V%2520-%2520OBJ.zip`

Compare that to the same file name correctly encoded in `relativeUrl`:
* `PROFIM%20Normo%20V%20-%20OBJ.zip`

The root cause is that when calculating the absolute  assetURL, the controller passes an already encoded argument to `IBlobUrlResolver.GetAbsoluteUrl()` which [does encoding of its own](https://github.com/VirtoCommerce/vc-module-azureblob-assets/blob/ab8c0607a79b43c672023481c4a5414586accb00/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs#L634-L644) (at least in Azure Blob Storage implementation). I'm assuming it's part of `IBlobUrlResolver`'s contract to encode that URL, not the caller's responsibility.