### PR TITLE
VCST-2347: Improve clarity of BlobFolderValidator error messages

### DIFF
--- a/src/VirtoCommerce.AssetsModule.Web/Validators/BlobFolderValidator.cs
+++ b/src/VirtoCommerce.AssetsModule.Web/Validators/BlobFolderValidator.cs
@@ -15,17 +15,17 @@ namespace VirtoCommerce.AssetsModule.Web.Validators
                 .NotEmpty()
                 .WithMessage("Folder name must not be empty.")
                 .MinimumLength(3)
-                .WithMessage(x => $"Minimum length is 3. You entered {x.Name.Length}")
+                .WithMessage(x => $"Folder name must be at least 3 characters long. You entered {x.Name.Length} characters.")
                 .MaximumLength(63)
-                .WithMessage(x => $"Maximum length is 63. You entered {x.Name.Length}")
+                .WithMessage(x => $"Folder name must be at most 63 characters long. You entered {x.Name.Length} characters.")
                 .Must(x => !x.StartsWith("-"))
-                .WithMessage("Folder name must not starts with dash symbol.")
+                .WithMessage("Folder name must not start with a dash symbol.")
                 .Must(x => !x.EndsWith("-"))
-                .WithMessage("Folder name must not ends with dash symbol.")
+                .WithMessage("Folder name must not end with a dash symbol.")
                 .Must(x => !x.Contains("--"))
                 .WithMessage("Folder name must not contain consecutive dash symbols.")
                 .Must(x => !new Regex("[^0-9a-z -]").IsMatch(x))
-                .WithMessage("Folder name must not contain special symbols.");
+                .WithMessage("Folder name must only contain lowercase letters, numbers, spaces, and single dashes.");
         }
     }
 }

--- a/src/VirtoCommerce.AssetsModule.Web/Validators/BlobFolderValidator.cs
+++ b/src/VirtoCommerce.AssetsModule.Web/Validators/BlobFolderValidator.cs
@@ -4,7 +4,7 @@ using VirtoCommerce.AssetsModule.Core.Assets;
 
 namespace VirtoCommerce.AssetsModule.Web.Validators
 {
-    public class BlobFolderValidator : AbstractValidator<BlobFolder>
+    public partial class BlobFolderValidator : AbstractValidator<BlobFolder>
     {
         public BlobFolderValidator()
         {
@@ -18,14 +18,17 @@ namespace VirtoCommerce.AssetsModule.Web.Validators
                 .WithMessage(x => $"Folder name must be at least 3 characters long. You entered {x.Name.Length} characters.")
                 .MaximumLength(63)
                 .WithMessage(x => $"Folder name must be at most 63 characters long. You entered {x.Name.Length} characters.")
-                .Must(x => !x.StartsWith("-"))
+                .Must(x => !x.StartsWith('-'))
                 .WithMessage("Folder name must not start with a dash symbol.")
-                .Must(x => !x.EndsWith("-"))
+                .Must(x => !x.EndsWith('-'))
                 .WithMessage("Folder name must not end with a dash symbol.")
                 .Must(x => !x.Contains("--"))
                 .WithMessage("Folder name must not contain consecutive dash symbols.")
-                .Must(x => !new Regex("[^0-9a-z -]").IsMatch(x))
+                .Must(x => !FolderNameRegex().IsMatch(x))
                 .WithMessage("Folder name must only contain lowercase letters, numbers, spaces, and single dashes.");
         }
+
+        [GeneratedRegex("[^0-9a-z -]")]
+        private static partial Regex FolderNameRegex();
     }
 }

--- a/tests/VirtoCommerce.AssetsModule.Tests/Validators/BlobFolderValidatorTests.cs
+++ b/tests/VirtoCommerce.AssetsModule.Tests/Validators/BlobFolderValidatorTests.cs
@@ -135,7 +135,7 @@ namespace VirtoCommerce.AssetsModule.Tests.Validators
 
             // Assert
             result.IsValid.Should().BeFalse();
-            result.Errors.Should().ContainSingle(x => x.PropertyName == "Name" && x.ErrorMessage.Contains("special symbols"));
+            result.Errors.Should().ContainSingle(x => x.PropertyName == "Name" && x.ErrorMessage.Contains("must only contain"));
         }
 
         [Fact]


### PR DESCRIPTION
## Description
fix: Improve clarity of BlobFolderValidator error messages

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-2347
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Assets_3.809.0-pr-25-b08d.zip