### PR TITLE
VCST-3998: Force assets download instead of open in new tab.

### DIFF
--- a/src/VirtoCommerce.AssetsModule.Web/Scripts/blades/asset-list.js
+++ b/src/VirtoCommerce.AssetsModule.Web/Scripts/blades/asset-list.js
@@ -82,7 +82,20 @@ angular.module('virtoCommerce.assetsModule')
             };
 
             $scope.downloadUrl = function (data) {
-                window.open(data.url, '_blank');
+                try {
+                    var link = document.createElement('a');
+                    link.href = data.url;
+                    link.download = data.name || 'file.txt'; 
+                    document.body.appendChild(link);
+
+                    link.click();
+
+                    document.body.removeChild(link);
+                } catch (err) {
+                    console.warn('Download fallback: opening in new tab due browser restriction', err);
+                    // Fallback: open in new tab
+                    window.open(data.url, '_blank');
+                }
             };
 
             function isItemsChecked() {

--- a/src/VirtoCommerce.AssetsModule.Web/package-lock.json
+++ b/src/VirtoCommerce.AssetsModule.Web/package-lock.json
@@ -416,10 +416,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"


### PR DESCRIPTION
## Description
feat: Updated the downloadUrl function to create a temporary anchor element for downloading files directly. If the download fails due to browser restrictions, it falls back to opening the URL in a new tab. This improves user experience by allowing direct file downloads instead of just viewing in the browser.

## References
### QA-test:
### Jira-link:
### Artifact URL:
