### PR TITLE
VCST-5163: Stable 15 — Assets (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.AssetsModule.Core/VirtoCommerce.AssetsModule.Core.csproj
+++ b/src/VirtoCommerce.AssetsModule.Core/VirtoCommerce.AssetsModule.Core.csproj
@@ -11,6 +11,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1026.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.AssetsModule.Data.MySql/VirtoCommerce.AssetsModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.AssetsModule.Data.MySql/VirtoCommerce.AssetsModule.Data.MySql.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1026.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.AssetsModule.Data\VirtoCommerce.AssetsModule.Data.csproj" />

--- a/src/VirtoCommerce.AssetsModule.Data.PostgreSql/VirtoCommerce.AssetsModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.AssetsModule.Data.PostgreSql/VirtoCommerce.AssetsModule.Data.PostgreSql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1026.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.AssetsModule.Data\VirtoCommerce.AssetsModule.Data.csproj" />

--- a/src/VirtoCommerce.AssetsModule.Data.SqlServer/VirtoCommerce.AssetsModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.AssetsModule.Data.SqlServer/VirtoCommerce.AssetsModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1026.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.AssetsModule.Data\VirtoCommerce.AssetsModule.Data.csproj" />

--- a/src/VirtoCommerce.AssetsModule.Data/VirtoCommerce.AssetsModule.Data.csproj
+++ b/src/VirtoCommerce.AssetsModule.Data/VirtoCommerce.AssetsModule.Data.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1026.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.AssetsModule.Core\VirtoCommerce.AssetsModule.Core.csproj" />

--- a/src/VirtoCommerce.AssetsModule.Web/module.manifest
+++ b/src/VirtoCommerce.AssetsModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.Assets</id>
   <version>3.1005.0</version>
   <version-tag />
-  <platformVersion>3.1026.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies />
   <title>Assets Management</title>
   <description>Common abstractions for asset search, retrieval, and manipulation, making it easy for developers to work with assets regardless of their underlying storage location.</description>


### PR DESCRIPTION
Part of **Stable 15** (Wave 1). Builds against the published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) from nuget.org.

- Platform -> **3.1039.0**; module version -> **3.1005.0**.
- `vc-build Compress` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin-only change with no code or behavior modifications; main risk is compatibility with platform 3.1039.0 at deploy time, which the PR description indicates was validated via build.
> 
> **Overview**
> **Stable 15 / Wave 1** alignment: all Virto Commerce **Platform** NuGet references move from **3.1026.0** to **3.1039.0**, and `module.manifest` **`platformVersion`** is updated to match.
> 
> Touched projects: **Core** (`VirtoCommerce.Platform.Core`), **Data** (`VirtoCommerce.Platform.Data`), and the **MySql**, **PostgreSql**, and **SqlServer** data provider packages. No runtime, API, or asset-handling logic changes—only dependency and manifest metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0de9a0d5395b251764f8dd8010327247be7af8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Assets_3.1005.0-pr-37-e0de.zip